### PR TITLE
add pin field

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_ui_kit/stories/buttons.dart';
 import 'package:flutter_ui_kit/stories/cards.dart';
 import 'package:flutter_ui_kit/stories/colors.dart';
+import 'package:flutter_ui_kit/stories/form_fields.dart';
 import 'package:flutter_ui_kit/stories/layouts.dart';
 import 'package:flutter_ui_kit/stories/numpads.dart';
 import 'package:flutter_ui_kit/stories/popover.dart';
@@ -24,7 +25,8 @@ void main() {
           AppCards(),
           Popover(),
           Layouts(),
-          Iconography()
+          Iconography(),
+          FormFields(),
         ],
       ),
     ),

--- a/lib/stories/form_fields.dart
+++ b/lib/stories/form_fields.dart
@@ -69,13 +69,13 @@ class FormFields extends StatelessWidget {
 
   Future<void> _showSnackBar(String pin, BuildContext context) async {
     final snackBar = SnackBar(
-      duration: Duration(seconds: 5),
+      duration: const Duration(seconds: 5),
       content: Container(
           height: 80.0,
           child: Center(
             child: Text(
               'Pin Submitted. Value: $pin',
-              style: TextStyle(fontSize: 25.0),
+              style: const TextStyle(fontSize: 25.0),
             ),
           )),
       backgroundColor: Colors.greenAccent,

--- a/lib/stories/form_fields.dart
+++ b/lib/stories/form_fields.dart
@@ -58,7 +58,7 @@ class FormFields extends StatelessWidget {
             child: PinField(
               fieldsCount: props['fieldsCount'],
               errorMessage: props['errorMessage'],
-              autofocus: props['autofocus'],
+              autoFocus: props['autofocus'],
               onSubmit: (String pin) => _showSnackBar(pin, context),
             ),
           );

--- a/lib/stories/form_fields.dart
+++ b/lib/stories/form_fields.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_ui_kit/story_book/expandable_story.dart';
+import 'package:flutter_ui_kit/story_book/prop_updater/bool_prop_updater.dart';
+import 'package:flutter_ui_kit/story_book/prop_updater/int_prop_updater.dart';
+import 'package:flutter_ui_kit/story_book/prop_updater/string_prop_updater.dart';
+import 'package:flutter_ui_kit/story_book/props_explorer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_ui_kit/widgets/form_fields/pin_field.dart';
+
+class FormFields extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _pinFieldsStory(),
+        ],
+      ),
+    );
+  }
+
+  Widget _pinFieldsStory() {
+    return ExpandableStory(
+      title: 'Pin Field',
+      child: PropsExplorer(
+        initialProps: const <String, dynamic>{
+          'fieldsCount': 3,
+          'errorMessage': '',
+          'autofocus': true
+        },
+        formBuilder: (context, props, updateProp) {
+          return ListView(
+            physics: const NeverScrollableScrollPhysics(),
+            shrinkWrap: true,
+            children: <Widget>[
+              IntPropUpdater(
+                props: props,
+                updateProp: updateProp,
+                propKey: 'fieldsCount',
+                hintText: 'number of fields',
+              ),
+              StringPropUpdater(
+                props: props,
+                updateProp: updateProp,
+                propKey: 'errorMessage',
+                hintText: 'error message',
+              ),
+              BoolPropUpdater(
+                props: props,
+                updateProp: updateProp,
+                propKey: 'autofocus',
+              ),
+            ],
+          );
+        },
+        widgetBuilder: (context, props) {
+          return Center(
+            child: PinField(
+              fieldsCount: props['fieldsCount'],
+              errorMessage: props['errorMessage'],
+              autofocus: props['autofocus'],
+              onSubmit: (String pin) => _showSnackBar(pin, context),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _showSnackBar(String pin, BuildContext context) async {
+    final snackBar = SnackBar(
+      duration: Duration(seconds: 5),
+      content: Container(
+          height: 80.0,
+          child: Center(
+            child: Text(
+              'Pin Submitted. Value: $pin',
+              style: TextStyle(fontSize: 25.0),
+            ),
+          )),
+      backgroundColor: Colors.greenAccent,
+    );
+    Scaffold.of(context).showSnackBar(snackBar);
+  }
+}

--- a/lib/widgets/form_fields/pin_field.dart
+++ b/lib/widgets/form_fields/pin_field.dart
@@ -22,7 +22,6 @@ class PinField extends StatefulWidget {
 
 class _PinFieldState extends State<PinField> {
   static const double _inputFieldWidth = 40.0;
-  static const double _inputFieldHeight = 40.0;
   static const double _inputPadding = 5.0;
 
   List<FocusNode> _focusNodes;

--- a/lib/widgets/form_fields/pin_field.dart
+++ b/lib/widgets/form_fields/pin_field.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_ui_kit/color.dart';
+
+typedef OnSubmit = Future<void> Function(String value);
+
+class PinField extends StatefulWidget {
+  final int fieldsCount;
+  final OnSubmit onSubmit;
+  final String errorMessage;
+  final bool autofocus;
+
+  PinField({
+    @required this.fieldsCount,
+    this.onSubmit,
+    this.errorMessage = '',
+    this.autofocus = false,
+  }) : assert(fieldsCount > 0);
+
+  @override
+  _PinFieldState createState() => _PinFieldState();
+}
+
+class _PinFieldState extends State<PinField> {
+  static const double _inputFieldWidth = 40.0;
+  static const double _inputFieldHeight = 40.0;
+  static const double _inputPadding = 5.0;
+
+  List<FocusNode> _focusNodes;
+  List<TextEditingController> _controllers;
+  List<String> _values;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _focusNodes = List.generate(widget.fieldsCount, (int i) => FocusNode());
+    _controllers = List.generate(
+        widget.fieldsCount, (int i) => TextEditingController(text: ''));
+    _values = _defaultValues();
+  }
+
+  List<String> _defaultValues() {
+    return List.generate(widget.fieldsCount, (_) => '');
+  }
+
+  @override
+  void dispose() {
+    _focusNodes.forEach((FocusNode f) => f.dispose());
+    _controllers.forEach((TextEditingController c) => c.dispose());
+
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final children = <Widget>[_generateTextFields(context)];
+    if (widget.errorMessage.isNotEmpty) {
+      children.add(Text(
+        widget.errorMessage,
+        style: textTheme.body1.copyWith(color: AppColor.red),
+      ));
+    }
+    return Container(
+      width: _getContainerWidth(),
+      child: Column(
+        children: children,
+      ),
+    );
+  }
+
+  double _getContainerWidth() {
+    return _inputPadding * 2 + widget.fieldsCount * _inputFieldWidth;
+  }
+
+  Widget _generateTextFields(BuildContext context) {
+    final textFields = <Widget>[];
+    for (var i = 0; i < widget.fieldsCount; ++i) {
+      textFields.add(_buildTextField(i, context));
+    }
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      verticalDirection: VerticalDirection.down,
+      children: textFields,
+    );
+  }
+
+  Widget _buildTextField(int index, BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final border = _getBorder(index);
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: _inputPadding),
+        child: Theme(
+          data: theme.copyWith(splashColor: Colors.transparent),
+          child: TextField(
+            keyboardType: TextInputType.number,
+            textInputAction: TextInputAction.next,
+            style: textTheme.body1,
+            decoration: InputDecoration(
+              contentPadding: const EdgeInsets.only(
+                  left: 10, right: 10, top: 8.0, bottom: 8.0),
+              enabledBorder: border,
+              focusedBorder: border,
+              counterText: '',
+            ),
+            textAlign: TextAlign.center,
+            maxLength: 1,
+            onTap: () => _handleTap(context),
+            controller: _controllers[index],
+            focusNode: _focusNodes[index],
+            onChanged: (_) => _handleChange(context),
+            autofocus: widget.autofocus && index == 0,
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _handleTap(BuildContext context) {
+    if (_allFieldsAreFilled()) {
+      _unFocusAll();
+    } else {
+      _focusOnFirstNonEmptyTextField(context);
+    }
+  }
+
+  void _handleChange(BuildContext context) async {
+    setState(() {
+      _values = _getValues();
+    });
+    if (_allFieldsAreFilled()) {
+      _unFocusAll();
+      await _triggerOnSubmit();
+      _clearAll();
+    } else {
+      _focusOnFirstNonEmptyTextField(context);
+    }
+  }
+
+  List<String> _getValues() {
+    return _controllers.map((TextEditingController c) => c.text).toList();
+  }
+
+  Future<void> _triggerOnSubmit() async {
+    if (widget.onSubmit != null) {
+      await widget.onSubmit(_values.join());
+    }
+  }
+
+  void _clearAll() {
+    _controllers.forEach((TextEditingController c) {
+      c.text = '';
+    });
+    setState(() {
+      _values = _defaultValues();
+    });
+  }
+
+  bool _allFieldsAreFilled() {
+    var result = true;
+    _values.forEach((String v) {
+      if (v.isEmpty) {
+        result = false;
+      }
+    });
+    return result;
+  }
+
+  void _focusOnFirstNonEmptyTextField(BuildContext context) {
+    final firstEmpty = _values.firstWhere((String v) => v.isEmpty);
+    final index = _values.indexOf(firstEmpty);
+    FocusScope.of(context).requestFocus(_focusNodes[index]);
+  }
+
+  void _unFocusAll() {
+    _focusNodes.forEach((fn) {
+      if (fn.hasFocus) {
+        fn.unfocus();
+      }
+    });
+  }
+
+  InputBorder _getBorder(int index) {
+    var borderColor = AppColor.grey;
+    if (_inputIsFilled(index)) {
+      borderColor = AppColor.green;
+    }
+    if (widget.errorMessage.isNotEmpty) {
+      borderColor = AppColor.red;
+    }
+    return UnderlineInputBorder(
+      borderSide: BorderSide(color: borderColor),
+      borderRadius: BorderRadius.zero,
+    );
+  }
+
+  bool _inputIsFilled(int index) {
+    return _values[index].isNotEmpty;
+  }
+}

--- a/lib/widgets/form_fields/pin_field.dart
+++ b/lib/widgets/form_fields/pin_field.dart
@@ -7,13 +7,13 @@ class PinField extends StatefulWidget {
   final int fieldsCount;
   final OnSubmit onSubmit;
   final String errorMessage;
-  final bool autofocus;
+  final bool autoFocus;
 
   PinField({
     @required this.fieldsCount,
     this.onSubmit,
     this.errorMessage = '',
-    this.autofocus = false,
+    this.autoFocus = false,
   }) : assert(fieldsCount > 0);
 
   @override
@@ -111,7 +111,7 @@ class _PinFieldState extends State<PinField> {
             controller: _controllers[index],
             focusNode: _focusNodes[index],
             onChanged: (_) => _handleChange(context),
-            autofocus: widget.autofocus && index == 0,
+            autofocus: widget.autoFocus && index == 0,
           ),
         ),
       ),

--- a/lib/widgets/form_fields/pin_field.dart
+++ b/lib/widgets/form_fields/pin_field.dart
@@ -159,13 +159,7 @@ class _PinFieldState extends State<PinField> {
   }
 
   bool _allFieldsAreFilled() {
-    var result = true;
-    _values.forEach((String v) {
-      if (v.isEmpty) {
-        result = false;
-      }
-    });
-    return result;
+    return _values.every((String v) => v.isNotEmpty);
   }
 
   void _focusOnFirstNonEmptyTextField(BuildContext context) {

--- a/test/widgets/form_fields/pin_field_test.dart
+++ b/test/widgets/form_fields/pin_field_test.dart
@@ -10,6 +10,12 @@ class OnSubmitMock extends Mock implements Function {
   Future<void> call(String value);
 }
 
+List<TextField> _findTextFields(WidgetTester tester) =>
+    tester.widgetList<TextField>(find.byType(TextField)).toList();
+
+TextField _findTextFieldAtIndex(WidgetTester tester, int index) =>
+    _findTextFields(tester)[index];
+
 void main() {
   group('Pin Field', () {
     testWidgets('renders correct number of inputs',
@@ -41,7 +47,7 @@ void main() {
           errorMessage: errorMessage,
         )));
 
-        final textFields = tester.widgetList<TextField>(find.byType(TextField));
+        final textFields = _findTextFields(tester);
         expect(textFields.length, 3);
         textFields.forEach((TextField tf) {
           expect(
@@ -66,10 +72,10 @@ void main() {
           onSubmit: onSubmit,
         )));
 
-        final textFields =
-            tester.widgetList<TextField>(find.byType(TextField)).toList();
         for (var i = 0; i < fieldsCount; i++) {
-          await tester.enterText(find.byWidget(textFields[i]), '1');
+          final currentTextField = _findTextFieldAtIndex(tester, i);
+          await tester.enterText(find.byWidget(currentTextField), '1');
+          await tester.pump();
         }
         verify(onSubmit('1111'));
       });
@@ -83,13 +89,12 @@ void main() {
           onSubmit: onSubmit,
         )));
 
-        final textFields =
-            tester.widgetList<TextField>(find.byType(TextField)).toList();
         for (var i = 0; i < fieldsCount; i++) {
-          await tester.enterText(find.byWidget(textFields[i]), '1');
+          final currentTextField = _findTextFieldAtIndex(tester, i);
+          await tester.enterText(find.byWidget(currentTextField), '1');
+          await tester.pump();
         }
         verify(onSubmit('1111'));
-        await tester.pump();
         expect(find.text('1'), findsNothing);
       });
     });
@@ -103,8 +108,7 @@ void main() {
           autofocus: true,
         )));
 
-        final textFields =
-            tester.widgetList<TextField>(find.byType(TextField)).toList();
+        final textFields = _findTextFields(tester);
         expect(textFields.first.focusNode.hasFocus, true);
         expect(textFields.last.focusNode.hasFocus, false);
       });
@@ -117,12 +121,12 @@ void main() {
           fieldsCount: fieldsCount,
         )));
 
-        final textFields =
-            tester.widgetList<TextField>(find.byType(TextField)).toList();
+        final firstTextField = _findTextFieldAtIndex(tester, 0);
         for (var i = 1; i < fieldsCount; i++) {
-          await tester.tap(find.byWidget(textFields[i]));
-          expect(textFields.first.focusNode.hasFocus, true);
-          expect(textFields[i].focusNode.hasFocus, false);
+          final currentTextField = _findTextFieldAtIndex(tester, i);
+          await tester.tap(find.byWidget(currentTextField));
+          expect(firstTextField.focusNode.hasFocus, true);
+          expect(currentTextField.focusNode.hasFocus, false);
         }
       });
 
@@ -134,14 +138,15 @@ void main() {
           fieldsCount: fieldsCount,
         )));
 
-        final textFields =
-            tester.widgetList<TextField>(find.byType(TextField)).toList();
-        await tester.enterText(find.byWidget(textFields.first), '1');
-        final secondTextField = textFields[1];
+        final firstTextField = _findTextFieldAtIndex(tester, 0);
+        await tester.enterText(find.byWidget(firstTextField), '1');
+        await tester.pump();
+        final secondTextField = _findTextFieldAtIndex(tester, 1);
         for (var i = 2; i < fieldsCount; i++) {
-          await tester.tap(find.byWidget(textFields[i]));
+          final currentTextField = _findTextFieldAtIndex(tester, i);
+          await tester.tap(find.byWidget(currentTextField));
           expect(secondTextField.focusNode.hasFocus, true);
-          expect(textFields[i].focusNode.hasFocus, false);
+          expect(currentTextField.focusNode.hasFocus, false);
         }
       });
 
@@ -152,12 +157,13 @@ void main() {
           fieldsCount: fieldsCount,
         )));
 
-        final textFields =
-            tester.widgetList<TextField>(find.byType(TextField)).toList();
+        final textFields = _findTextFields(tester);
+        expect(textFields.length, 4);
         for (var i = 0; i < fieldsCount - 1; i++) {
-          final currentTextField = textFields[i];
+          final currentTextField = _findTextFieldAtIndex(tester, i);
           await tester.enterText(find.byWidget(currentTextField), '1');
-          final nextTextField = textFields[i + 1];
+          await tester.pump();
+          final nextTextField = _findTextFieldAtIndex(tester, i + 1);
           expect(nextTextField.focusNode.hasFocus, true);
         }
       });
@@ -170,13 +176,14 @@ void main() {
           fieldsCount: fieldsCount,
         )));
 
-        final textFields =
-            tester.widgetList<TextField>(find.byType(TextField)).toList();
         for (var i = 0; i < fieldsCount - 1; i++) {
-          await tester.enterText(find.byWidget(textFields[i]), '1');
+          final currentTextField = _findTextFieldAtIndex(tester, i);
+          await tester.enterText(find.byWidget(currentTextField), '1');
+          await tester.pump();
         }
-        await tester.enterText(find.byWidget(textFields.last), '1');
-        expect(textFields.last.focusNode.hasFocus, false);
+        final lastTextField = _findTextFieldAtIndex(tester, fieldsCount - 1);
+        await tester.enterText(find.byWidget(lastTextField), '1');
+        expect(lastTextField.focusNode.hasFocus, false);
       });
     });
 
@@ -187,7 +194,7 @@ void main() {
           fieldsCount: 3,
         )));
 
-        final textFields = tester.widgetList<TextField>(find.byType(TextField));
+        final textFields = _findTextFields(tester);
         expect(textFields.length, 3);
         textFields.forEach((TextField tf) {
           expect(
@@ -213,7 +220,7 @@ void main() {
         );
         await tester.pump();
 
-        final textFields = tester.widgetList<TextField>(find.byType(TextField));
+        final textFields = _findTextFields(tester);
         expect(textFields.length, 2);
         expect(
           textFields.first.decoration.enabledBorder.borderSide.color,

--- a/test/widgets/form_fields/pin_field_test.dart
+++ b/test/widgets/form_fields/pin_field_test.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_ui_kit/color.dart';
+import 'package:flutter_ui_kit/widgets/form_fields/pin_field.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../wrap_in_material_app.dart';
+
+class OnSubmitMock extends Mock implements Function {
+  Future<void> call(String value);
+}
+
+void main() {
+  group('Pin Field', () {
+    testWidgets('renders correct number of inputs',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(wrapInMaterialApp(PinField(
+        fieldsCount: 3,
+      )));
+
+      expect(find.byType(TextField), findsNWidgets(3));
+    });
+
+    group('error message', () {
+      testWidgets('renders error message if it is passed',
+          (WidgetTester tester) async {
+        const errorMessage = 'some error occured';
+        await tester.pumpWidget(wrapInMaterialApp(PinField(
+          fieldsCount: 3,
+          errorMessage: errorMessage,
+        )));
+
+        expect(find.text(errorMessage), findsOneWidget);
+      });
+
+      testWidgets('renders red border if error message is passed',
+          (WidgetTester tester) async {
+        const errorMessage = 'some error occured';
+        await tester.pumpWidget(wrapInMaterialApp(PinField(
+          fieldsCount: 3,
+          errorMessage: errorMessage,
+        )));
+
+        final textFields = tester.widgetList<TextField>(find.byType(TextField));
+        expect(textFields.length, 3);
+        textFields.forEach((TextField tf) {
+          expect(
+            tf.decoration.enabledBorder.borderSide.color,
+            AppColor.red,
+          );
+          expect(
+            tf.decoration.focusedBorder.borderSide.color,
+            AppColor.red,
+          );
+        });
+      });
+    });
+
+    group('onSubmit', () {
+      testWidgets('should trigger onSubmit when all inputs are filled',
+          (WidgetTester tester) async {
+        const fieldsCount = 4;
+        final onSubmit = OnSubmitMock().call;
+        await tester.pumpWidget(wrapInMaterialApp(PinField(
+          fieldsCount: fieldsCount,
+          onSubmit: onSubmit,
+        )));
+
+        final textFields =
+            tester.widgetList<TextField>(find.byType(TextField)).toList();
+        for (var i = 0; i < fieldsCount; i++) {
+          await tester.enterText(find.byWidget(textFields[i]), '1');
+        }
+        verify(onSubmit('1111'));
+      });
+
+      testWidgets('clears all inputs after submit',
+          (WidgetTester tester) async {
+        const fieldsCount = 4;
+        final onSubmit = OnSubmitMock().call;
+        await tester.pumpWidget(wrapInMaterialApp(PinField(
+          fieldsCount: fieldsCount,
+          onSubmit: onSubmit,
+        )));
+
+        final textFields =
+            tester.widgetList<TextField>(find.byType(TextField)).toList();
+        for (var i = 0; i < fieldsCount; i++) {
+          await tester.enterText(find.byWidget(textFields[i]), '1');
+        }
+        verify(onSubmit('1111'));
+        await tester.pump();
+        expect(find.text('1'), findsNothing);
+      });
+    });
+
+    group('focus', () {
+      testWidgets('if autofocus is set to true then focuses on first input',
+          (WidgetTester tester) async {
+        const fieldsCount = 4;
+        await tester.pumpWidget(wrapInMaterialApp(PinField(
+          fieldsCount: fieldsCount,
+          autofocus: true,
+        )));
+
+        final textFields =
+            tester.widgetList<TextField>(find.byType(TextField)).toList();
+        expect(textFields.first.focusNode.hasFocus, true);
+        expect(textFields.last.focusNode.hasFocus, false);
+      });
+
+      testWidgets(
+          'if first input is empty, tapping on any input would focus on the first input',
+          (WidgetTester tester) async {
+        const fieldsCount = 4;
+        await tester.pumpWidget(wrapInMaterialApp(PinField(
+          fieldsCount: fieldsCount,
+        )));
+
+        final textFields =
+            tester.widgetList<TextField>(find.byType(TextField)).toList();
+        for (var i = 1; i < fieldsCount; i++) {
+          await tester.tap(find.byWidget(textFields[i]));
+          expect(textFields.first.focusNode.hasFocus, true);
+          expect(textFields[i].focusNode.hasFocus, false);
+        }
+      });
+
+      testWidgets(
+          'if first input is not empty, should focus on the second input',
+          (WidgetTester tester) async {
+        const fieldsCount = 4;
+        await tester.pumpWidget(wrapInMaterialApp(PinField(
+          fieldsCount: fieldsCount,
+        )));
+
+        final textFields =
+            tester.widgetList<TextField>(find.byType(TextField)).toList();
+        await tester.enterText(find.byWidget(textFields.first), '1');
+        final secondTextField = textFields[1];
+        for (var i = 2; i < fieldsCount; i++) {
+          await tester.tap(find.byWidget(textFields[i]));
+          expect(secondTextField.focusNode.hasFocus, true);
+          expect(textFields[i].focusNode.hasFocus, false);
+        }
+      });
+
+      testWidgets('if input is filled should focus on the next input',
+          (WidgetTester tester) async {
+        const fieldsCount = 4;
+        await tester.pumpWidget(wrapInMaterialApp(PinField(
+          fieldsCount: fieldsCount,
+        )));
+
+        final textFields =
+            tester.widgetList<TextField>(find.byType(TextField)).toList();
+        for (var i = 0; i < fieldsCount - 1; i++) {
+          final currentTextField = textFields[i];
+          await tester.enterText(find.byWidget(currentTextField), '1');
+          final nextTextField = textFields[i + 1];
+          expect(nextTextField.focusNode.hasFocus, true);
+        }
+      });
+
+      testWidgets(
+          'when all inputs are filled should unfocus from the last input',
+          (WidgetTester tester) async {
+        const fieldsCount = 4;
+        await tester.pumpWidget(wrapInMaterialApp(PinField(
+          fieldsCount: fieldsCount,
+        )));
+
+        final textFields =
+            tester.widgetList<TextField>(find.byType(TextField)).toList();
+        for (var i = 0; i < fieldsCount - 1; i++) {
+          await tester.enterText(find.byWidget(textFields[i]), '1');
+        }
+        await tester.enterText(find.byWidget(textFields.last), '1');
+        expect(textFields.last.focusNode.hasFocus, false);
+      });
+    });
+
+    group('style', () {
+      testWidgets('renders grey border by default',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(wrapInMaterialApp(PinField(
+          fieldsCount: 3,
+        )));
+
+        final textFields = tester.widgetList<TextField>(find.byType(TextField));
+        expect(textFields.length, 3);
+        textFields.forEach((TextField tf) {
+          expect(
+            tf.decoration.enabledBorder.borderSide.color,
+            AppColor.grey,
+          );
+          expect(
+            tf.decoration.focusedBorder.borderSide.color,
+            AppColor.grey,
+          );
+        });
+      });
+
+      testWidgets('renders green border if input is filled',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(wrapInMaterialApp(PinField(
+          fieldsCount: 2,
+        )));
+
+        await tester.enterText(
+          find.byType(TextField).first,
+          '1',
+        );
+        await tester.pump();
+
+        final textFields = tester.widgetList<TextField>(find.byType(TextField));
+        expect(textFields.length, 2);
+        expect(
+          textFields.first.decoration.enabledBorder.borderSide.color,
+          AppColor.green,
+        );
+        expect(
+          textFields.last.decoration.enabledBorder.borderSide.color,
+          AppColor.grey,
+        );
+      });
+    });
+  });
+}

--- a/test/widgets/form_fields/pin_field_test.dart
+++ b/test/widgets/form_fields/pin_field_test.dart
@@ -105,7 +105,7 @@ void main() {
         const fieldsCount = 4;
         await tester.pumpWidget(wrapInMaterialApp(PinField(
           fieldsCount: fieldsCount,
-          autofocus: true,
+          autoFocus: true,
         )));
 
         final textFields = _findTextFields(tester);


### PR DESCRIPTION
This PR introduces PinField component.

Initially I used [PinPut](https://github.com/Tkko/Flutter_PinPut/tree/master/lib/pin_put) widget as underlying widget, but it was difficult for me to clear the input from that widget after submit.

So I decided to have fully custom solution taking the main ideas from this library.

On the high level `PinField` renders n `TextFields` (n is the param for number of fields). Each `TextField` can only contain 1 character. 

Given this approach the main challenge is to orchestrate changing focus from input to input and keep track of changes. Changing focus from input to input is tackled with list of `FocusNode`s for each input, which gives the ability to `focus` or `unfocus` on any `TextField`. Keeping track of changes is done via list of `TextEditingController`s that are passed to each `TextField`