### PR TITLE
fixed EN-510 The portfolio balance big number is covering the small n…

### DIFF
--- a/lib/stories/currency_displays.dart
+++ b/lib/stories/currency_displays.dart
@@ -4,6 +4,7 @@ import 'package:flutter_ui_kit/story_book/prop_updater/bool_prop_updater.dart';
 import 'package:flutter_ui_kit/story_book/prop_updater/double_prop_updater.dart';
 import 'package:flutter_ui_kit/story_book/prop_updater/string_prop_updater.dart';
 import 'package:flutter_ui_kit/story_book/props_explorer.dart';
+import 'package:flutter_ui_kit/widgets/asset_rate.dart';
 import 'package:flutter_ui_kit/widgets/currency_display.dart';
 import 'package:flutter_ui_kit/widgets/currency_switcher.dart';
 
@@ -16,6 +17,7 @@ class CurrencyDisplays extends StatelessWidget {
           children: <Widget>[
             _currencyDisplayStory(),
             _currencySwitcherStory(),
+            _assetRateStory(),
           ],
         ),
       ),
@@ -100,6 +102,41 @@ class CurrencyDisplays extends StatelessWidget {
               CurrencyInfo(label: 'BTC', symbol: 'BTC')
             ],
           );
+        },
+      ),
+    );
+  }
+
+  Widget _assetRateStory() {
+    return ExpandableStory(
+      title: 'Asset Rate',
+      child: PropsExplorer(
+        initialProps: const <String, dynamic>{
+          'currencySymbol': '€',
+          'amount': 1792.28
+        },
+        formBuilder: (context, props, updateProp) {
+          return ListView(
+            physics: const NeverScrollableScrollPhysics(),
+            shrinkWrap: true,
+            children: <Widget>[
+              StringPropUpdater(
+                  props: props,
+                  updateProp: updateProp,
+                  propKey: 'currencySymbol'),
+              DoublePropUpdater(
+                  props: props,
+                  updateProp: updateProp,
+                  propKey: 'amount',
+                  min: 0,
+                  max: 999999999),
+            ],
+          );
+        },
+        widgetBuilder: (context, props) {
+          final double amount = props['amount'];
+          final String symbol = props['currencySymbol'];
+          return AssetRate(symbol, amount);
         },
       ),
     );

--- a/lib/widgets/asset_rate.dart
+++ b/lib/widgets/asset_rate.dart
@@ -11,24 +11,22 @@ class AssetRate extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context).textTheme;
     final formattedNumber = intl.NumberFormat('#,##0.00', 'en_US').format(rate);
     final value = formattedNumber.toString().substring(0, formattedNumber.indexOf('.'));
     final cents = formattedNumber.toString().substring(formattedNumber.indexOf('.'));
     return Column(
       children: <Widget>[
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.baseline,
-          textBaseline: TextBaseline.alphabetic,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            new Text('$symbol ',
-                style: AppText.body2),
-            new Text('$value',
-                style: AppText.header0.copyWith(fontWeight: FontWeight.bold)),
-            new Text('$cents',
-                style: theme.body2),
-          ],
+        RichText(
+          text: TextSpan(
+              children: [
+                new TextSpan(text: '$symbol ',
+                    style: AppText.body2),
+                new TextSpan(text: '$value',
+                    style: AppText.header0.copyWith(fontWeight: FontWeight.bold)),
+                new TextSpan(text: '$cents',
+                    style: AppText.body2),
+              ]
+          )
         )
       ],
     );

--- a/test/widgets/asset_rate_test.dart
+++ b/test/widgets/asset_rate_test.dart
@@ -10,11 +10,10 @@ void main() {
       const rate = 8750.1;
       await tester.pumpWidget(wrapInMaterialApp(const AssetRate(symbol, rate)));
       expect(find.byType(Column), findsOneWidget);
-      expect(find.byType(Row), findsOneWidget);
-      expect(find.byType(Text).evaluate().length, 3);
-      expect(find.text('€ '), findsOneWidget);
-      expect(find.text('8,750'), findsOneWidget);
-      expect(find.text('.10'), findsOneWidget);
+      expect(find.byType(RichText), findsOneWidget);
+      final RichText richText = find.byType(RichText).evaluate().first.widget;
+      final richTextText = richText.text.toPlainText();
+      expect(richTextText, '€ 8,750.10');
     });
 
     testWidgets('renders negative value', (WidgetTester tester) async {
@@ -22,11 +21,10 @@ void main() {
       const rate = -8701.478;
       await tester.pumpWidget(wrapInMaterialApp(const AssetRate(symbol, rate)));
       expect(find.byType(Column), findsOneWidget);
-      expect(find.byType(Row), findsOneWidget);
-      expect(find.byType(Text).evaluate().length, 3);
-      expect(find.text('€ '), findsOneWidget);
-      expect(find.text('-8,701'), findsOneWidget);
-      expect(find.text('.48'), findsOneWidget);
+      expect(find.byType(RichText), findsOneWidget);
+      final RichText richText = find.byType(RichText).evaluate().first.widget;
+      final richTextText = richText.text.toPlainText();
+      expect(richTextText, '€ -8,701.48');
     });
   });
 }


### PR DESCRIPTION

## Description

Fix for bug EN-510 The portfolio balance big number is covering the small number

## Issue
(# EN-510)

## Testing scenarios

- [ ] Scenarios 1: Issue is not reproducible for every number. Known value to reproduce is 1,792.28

## Impact

AssetRate widget was updated. It's used in 3 places: Portfolio balance value, Asset Rate and Card Balance.

## Rollback

Revert commit

___

Owner: Vadim

