### PR TITLE
Add secondary action to passcode numpad text

### DIFF
--- a/lib/stories/numpads.dart
+++ b/lib/stories/numpads.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_ui_kit/color.dart';
 import 'package:flutter_ui_kit/story_book/expandable_story.dart';
 import 'package:flutter_ui_kit/story_book/prop_updater/bool_prop_updater.dart';
 import 'package:flutter_ui_kit/story_book/prop_updater/int_prop_updater.dart';
@@ -100,6 +101,7 @@ class _PasscodeNumpadStory extends StatelessWidget {
               'textLengthLimit': 0,
               'actionButtonText': 'Action',
               'enabled': true,
+              'hasSecondaryActionButton': false,
             },
             formBuilder: (context, props, updateProp) {
               return ListView(physics: const NeverScrollableScrollPhysics(), shrinkWrap: true, children: <Widget>[
@@ -119,6 +121,11 @@ class _PasscodeNumpadStory extends StatelessWidget {
                   props: props,
                   updateProp: updateProp,
                   propKey: 'enabled',
+                ),
+                BoolPropUpdater(
+                  props: props,
+                  updateProp: updateProp,
+                  propKey: 'hasSecondaryActionButton',
                 ),
               ]);
             },
@@ -148,8 +155,26 @@ class _PasscodeNumpadStory extends StatelessWidget {
                       textLengthLimit: props['textLengthLimit'],
                       actionButtonText: props['actionButtonText'],
                       enabled: props['enabled'],
+                      onActionbuttonPressed: () {
+                        _showDialog(context, '', 'Action button pressed');
+                      },
+                      hasSecondaryActionButton: props['hasSecondaryActionButton'],
+                      secondaryActionWidget: Icon(Icons.fingerprint, color: AppColor.green, size: 25),
+                      onSecondaryActionButtonPressed: () {
+                        _showDialog(context, '', 'Secondary action button pressed');
+                      },
                     ))
               ]);
             }));
+  }
+
+  void _showDialog(BuildContext context, String title, String text) {
+    showDialog<void>(
+        context: context,
+        builder: (_) => AlertDialog(
+              title: Text(title),
+              content: Text(text),
+            ));
+    print('Action button pressed');
   }
 }

--- a/lib/widgets/text/passcode_numpad_text.dart
+++ b/lib/widgets/text/passcode_numpad_text.dart
@@ -11,6 +11,9 @@ class PasscodeNumPadText extends StatefulWidget {
   final String actionButtonText;
   final VoidCallback onActionbuttonPressed;
   final bool enabled;
+  final bool hasSecondaryActionButton;
+  final Widget secondaryActionWidget;
+  final VoidCallback onSecondaryActionButtonPressed;
 
   const PasscodeNumPadText({
     @required this.onChange,
@@ -19,7 +22,10 @@ class PasscodeNumPadText extends StatefulWidget {
     this.actionButtonText,
     this.onActionbuttonPressed,
     this.enabled = true,
-  });
+    this.hasSecondaryActionButton = false,
+    this.secondaryActionWidget,
+    this.onSecondaryActionButtonPressed,
+  }) : assert(!(hasSecondaryActionButton == true && secondaryActionWidget == null));
 
   @override
   _PasscodeNumPadTextState createState() => _PasscodeNumPadTextState();
@@ -50,6 +56,7 @@ class _PasscodeNumPadTextState extends State<PasscodeNumPadText> {
       _text = _text.isNotEmpty ? _text.substring(0, _text.length - 1) : '';
     }
 
+    setState(() {});
     widget.onChange(_text);
   }
 
@@ -57,7 +64,34 @@ class _PasscodeNumPadTextState extends State<PasscodeNumPadText> {
     final isActionButton = val == widget.actionButtonText;
     final actionButtonStyle =
         AppText.numPadTextStyle.copyWith(color: AppColor.darkerGreen, fontWeight: FontWeight.normal, fontSize: 16);
-    return _KeyItem(
+    Widget child;
+    if (val != 'C') {
+      child = Text(val,
+          textAlign: TextAlign.center,
+          style: isActionButton
+              ? actionButtonStyle
+              : (enabled ? AppText.numPadTextStyle : AppText.numPadTextStyle.copyWith(color: AppColor.semiGrey)));
+    } else {
+      if (widget.hasSecondaryActionButton && _text.trim().isEmpty) {
+        child = widget.secondaryActionWidget;
+      } else {
+        child = Icon(Icons.arrow_back, size: 24.0, color: enabled ? AppColor.deepBlack : AppColor.semiGrey);
+      }
+    }
+
+    Function(String value) onKeyTap;
+    if (val == widget.actionButtonText && widget.onActionbuttonPressed != null) {
+      onKeyTap = (_) => widget.onActionbuttonPressed();
+    } else if (val == 'C' &&
+        widget.hasSecondaryActionButton &&
+        widget.onSecondaryActionButtonPressed != null &&
+        _text.trim().isEmpty) {
+      onKeyTap = (_) => widget.onSecondaryActionButtonPressed();
+    } else {
+      onKeyTap = widget.enabled ? onKeyTapped : null;
+    }
+
+    /*return _KeyItem(
       value: val,
       child: (val != 'C')
           ? Text(val,
@@ -69,6 +103,11 @@ class _PasscodeNumPadTextState extends State<PasscodeNumPadText> {
       onKeyTap: (val == widget.actionButtonText && widget.onActionbuttonPressed != null)
           ? (_) => widget.onActionbuttonPressed()
           : (enabled ? onKeyTapped : null),
+    );*/
+    return _KeyItem(
+      value: val,
+      child: child,
+      onKeyTap: onKeyTap,
     );
   }
 

--- a/test/widgets/text/passcode_numpad_text_test.dart
+++ b/test/widgets/text/passcode_numpad_text_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_ui_kit/widgets/text/passcode_numpad_text.dart';
 import '../../wrap_in_material_app.dart';
 
 void main() {
-
   group('NumPadText create test', () {
     final _textEditingController = TextEditingController();
     void onChangeTextField(String value) {
@@ -14,8 +13,7 @@ void main() {
     }
 
     testWidgets('renders numpad widget', (WidgetTester tester) async {
-      await tester.pumpWidget(wrapInMaterialApp(
-          PasscodeNumPadText(onChange: onChangeTextField)));
+      await tester.pumpWidget(wrapInMaterialApp(PasscodeNumPadText(onChange: onChangeTextField)));
       expect(find.widgetWithIcon(PasscodeNumPadText, Icons.arrow_back), findsOneWidget);
     });
   });
@@ -27,7 +25,7 @@ void main() {
     }
 
     testWidgets('on tap key tests', (WidgetTester tester) async {
-      final testNumPad = PasscodeNumPadText(onChange: onChange,textLengthLimit: 4);
+      final testNumPad = PasscodeNumPadText(onChange: onChange, textLengthLimit: 4);
       await tester.pumpWidget(wrapInMaterialApp(testNumPad));
       await tester.tap(find.text('1'));
       await tester.tap(find.text('2'));
@@ -41,6 +39,37 @@ void main() {
       await tester.tap(find.text('3'));
       await tester.pump();
       expect(_textEditingController.text, '1231');
+    });
+
+    testWidgets('shows secondary action when no text has been entered', (WidgetTester tester) async {
+      const secondaryWidget = const Text('Secondary Action', key: const Key('secondaryActionWidget'));
+
+      final testNumPad = PasscodeNumPadText(
+        onChange: onChange,
+        textLengthLimit: 4,
+        onSecondaryActionButtonPressed: () {},
+        secondaryActionWidget: secondaryWidget,
+        hasSecondaryActionButton: true,
+      );
+
+      await tester.pumpWidget(wrapInMaterialApp(testNumPad));
+      await tester.pump();
+      expect(find.byKey(const Key('secondaryActionWidget')), findsOneWidget);
+
+      await tester.tap(find.text('1'));
+      await tester.tap(find.text('2'));
+      await tester.tap(find.text('3'));
+      await tester.pump();
+      expect(find.byKey(const Key('secondaryActionWidget')), findsNothing);
+
+      await tester.tap(find.byIcon(Icons.arrow_back));
+      await tester.tap(find.byIcon(Icons.arrow_back));
+      await tester.tap(find.byIcon(Icons.arrow_back));
+      await tester.pump();
+      expect(find.byKey(const Key('secondaryActionWidget')), findsOneWidget);
+
+      await tester.pump();
+      expect(_textEditingController.text, '');
     });
   });
 }


### PR DESCRIPTION
## Description

Updated the numpad text to have a secondary action button that shows up where the C button should be before any text is entered and is hidden when user begins typing.

## Issue
https://change-finance.atlassian.net/browse/DOPE-600

## Testing scenarios

- [ ] Scenarios 1: Passcode numpad text should show a secondary action when no text has been entered but show the default delete button when text has been entered
- [ ] Scenarios 2: Deleting all the entered text should cause the secondary action to be shown again

## Impact

Passcode & Biometric Login on resume can use this feature

## Rollback
Revert commit

___

Owner: Tomi

QA Tester: 

Approved: 
