### PR TITLE
add more time frames to time frame selector

### DIFF
--- a/lib/widgets/time_frame_selector.dart
+++ b/lib/widgets/time_frame_selector.dart
@@ -6,52 +6,27 @@ import 'package:flutter_ui_kit/widgets/text_button.dart';
 
 typedef Callback = void Function(String value);
 
-enum TimeFrame {
-  ONE_HOUR,
-  ONE_DAY,
-  ONE_WEEK,
-  ONE_MONTH,
-  ONE_YEAR,
-  FIVE_YEARS
-}
+enum TimeFrame { ONE_HOUR, ONE_DAY, ONE_WEEK, ONE_MONTH, THREE_MONTHS, SIX_MONTHS, ONE_YEAR, THREE_YEARS, FIVE_YEARS }
 
 class TimeFrameHelper {
+  static const Map<String, TimeFrame> timeFrames = {
+    '1H': TimeFrame.ONE_HOUR,
+    '1D': TimeFrame.ONE_DAY,
+    '1W': TimeFrame.ONE_WEEK,
+    '1M': TimeFrame.ONE_MONTH,
+    '3M': TimeFrame.THREE_MONTHS,
+    '6M': TimeFrame.SIX_MONTHS,
+    '1Y': TimeFrame.ONE_YEAR,
+    '3Y': TimeFrame.THREE_YEARS,
+    '5Y': TimeFrame.FIVE_YEARS,
+  };
+
   static TimeFrame getKey(String timeFrame) {
-    switch (timeFrame) {
-      case '1H':
-        return TimeFrame.ONE_HOUR;
-      case '1D':
-        return TimeFrame.ONE_DAY;
-      case '1W':
-        return TimeFrame.ONE_WEEK;
-      case '1M':
-        return TimeFrame.ONE_MONTH;
-      case '1Y':
-        return TimeFrame.ONE_YEAR;
-      case '5Y':
-        return TimeFrame.FIVE_YEARS;
-      default:
-        return null;
-    }
+    return timeFrames[timeFrame];
   }
 
   static String getValue(TimeFrame timeFrame) {
-    switch (timeFrame) {
-      case TimeFrame.ONE_HOUR:
-        return '1H';
-      case TimeFrame.ONE_DAY:
-        return '1D';
-      case TimeFrame.ONE_WEEK:
-        return '1W';
-      case TimeFrame.ONE_MONTH:
-        return '1M';
-      case TimeFrame.ONE_YEAR:
-        return '1Y';
-      case TimeFrame.FIVE_YEARS:
-        return '5Y';
-      default:
-        return 'ERROR';
-    }
+    return timeFrames.entries.firstWhere((entry) => entry.value == timeFrame, orElse: () => null)?.key ?? 'ERROR';
   }
 }
 
@@ -59,12 +34,15 @@ class TimeFrameSelector extends StatefulWidget {
   final Callback onChange;
   final TimeFrame defaultTimeFrame;
   final TimeFrame maxTimeFrame;
+  final List<TimeFrame> exclude;
 
-  const TimeFrameSelector({Key key,
+  const TimeFrameSelector({
+    Key key,
+    this.exclude = const [TimeFrame.THREE_MONTHS, TimeFrame.SIX_MONTHS, TimeFrame.THREE_YEARS],
     this.defaultTimeFrame = TimeFrame.ONE_DAY,
     this.maxTimeFrame = TimeFrame.ONE_YEAR,
-    this.onChange})
-      : super(key: key);
+    this.onChange,
+  }) : super(key: key);
 
   @override
   TimeFrameSelectorWidgetState createState() => TimeFrameSelectorWidgetState();
@@ -92,50 +70,36 @@ class TimeFrameSelectorWidgetState extends State<TimeFrameSelector> {
       _onPressedPeriod(selected);
     }
 
-    final checkedButton = FilledButton(
-        TimeFrameHelper.getValue(selected),
+    final checkedButton = FilledButton(TimeFrameHelper.getValue(selected),
         onPressed: onPressed,
         textStyle: AppText.graphTextStyle.copyWith(color: AppColor.deepWhite),
-        padding: const EdgeInsets.all(0.0)
-    );
+        padding: const EdgeInsets.all(0.0));
     final uncheckedButton = TextButton(
       TimeFrameHelper.getValue(selected),
-        onPressed: onPressed,
-        textStyle: AppText.graphTextStyle.copyWith(color: AppColor.deepBlack),
-        padding: const EdgeInsets.all(0.0),
-    );
-
-    return Expanded(
-        flex: 1 ,
-        child: Container(
-            height: 22.0 ,
-            child: (selectedTimeFrame == selected) ? checkedButton : uncheckedButton
-        )
-    );
-  }
-
-  Expanded _buildDisableItem(TimeFrame selected) {
-    final uncheckedButton = TextButton(
-        TimeFrameHelper.getValue(selected),
-        textStyle: AppText.graphTextStyle.copyWith(color: AppColor.semiGrey),
-        padding: const EdgeInsets.all(0.0)
+      onPressed: onPressed,
+      textStyle: AppText.graphTextStyle.copyWith(color: AppColor.deepBlack),
+      padding: const EdgeInsets.all(0.0),
     );
 
     return Expanded(
         flex: 1,
-        child: Container(
-            height: 22.0,
-            child: uncheckedButton
-        )
-    );
+        child: Container(height: 22.0, child: (selectedTimeFrame == selected) ? checkedButton : uncheckedButton));
+  }
+
+  Expanded _buildDisableItem(TimeFrame selected) {
+    final uncheckedButton = TextButton(TimeFrameHelper.getValue(selected),
+        textStyle: AppText.graphTextStyle.copyWith(color: AppColor.semiGrey), padding: const EdgeInsets.all(0.0));
+
+    return Expanded(flex: 1, child: Container(height: 22.0, child: uncheckedButton));
   }
 
   @override
   Widget build(BuildContext context) {
     final widgets = <Widget>[];
-    final timeFrames = TimeFrame.values.toList();
+    final allTimeFrames = TimeFrame.values.where((tf) => !widget.exclude.contains(tf)).toList();
+    final timeFrames = <TimeFrame>[]..addAll(allTimeFrames);
 
-    for (var timeFrame in TimeFrame.values) {
+    for (var timeFrame in allTimeFrames) {
       widgets.add(_buildItem(timeFrame));
       timeFrames.remove(timeFrame);
       if (timeFrame == widget.maxTimeFrame) {
@@ -150,7 +114,6 @@ class TimeFrameSelectorWidgetState extends State<TimeFrameSelector> {
     return new Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: widgets
-    );
+        children: widgets);
   }
 }


### PR DESCRIPTION
## Description

Update the timeframe selector widget to handle more time frames.

## Issue
N/A

## Testing scenarios

- [ ] Scenarios 1: Make sure time frame selector still works as before and can show more time frames

## Impact

Allows us to use this widget for the interest account projection graph

## Rollback

Revert commit

___

Owner: Tomi

QA Tester: 

Approved:
