### PR TITLE
make switcher hideable

### DIFF
--- a/lib/widgets/currency_switcher.dart
+++ b/lib/widgets/currency_switcher.dart
@@ -35,12 +35,14 @@ class CurrencySwitcher extends StatefulWidget {
   final List<String> amounts;
   final Function(int) onSwitch;
   final bool onlySwitchedAmount;
+  final bool hideSwitcher;
 
   CurrencySwitcher({
         @required this.currencyInfoList,
         @required this.amounts,
         this.onSwitch,
-        this.onlySwitchedAmount = false
+        this.onlySwitchedAmount = false,
+        this.hideSwitcher = false,
       })
       : assert(currencyInfoList != null && currencyInfoList.length == 2);
 
@@ -74,7 +76,7 @@ class _CurrencySwitcherState extends State<CurrencySwitcher> {
           ),
           Padding(
             padding: const EdgeInsets.only(bottom: 4.0),
-            child: SwitcherButton(
+            child: widget.hideSwitcher ? Container() : SwitcherButton(
               labels: [infoList[0].label, infoList[1].label],
               onSwitch: _switch,
             ),


### PR DESCRIPTION
## Description

Make currency switcher hideable

## Issue
(#DOPE-123)

## Testing scenarios

- [ ] Scenarios 1: Make sure hideSwitcher property can be used to hide the currency switcher

## Impact


## Rollback

Revert commit

___

Owner:

QA Tester:

Approved:
