### PR TITLE
change hideable implementation

### DIFF
--- a/lib/widgets/currency_switcher.dart
+++ b/lib/widgets/currency_switcher.dart
@@ -76,9 +76,12 @@ class _CurrencySwitcherState extends State<CurrencySwitcher> {
           ),
           Padding(
             padding: const EdgeInsets.only(bottom: 4.0),
-            child: widget.hideSwitcher ? Container() : SwitcherButton(
-              labels: [infoList[0].label, infoList[1].label],
-              onSwitch: _switch,
+            child: Opacity(
+              opacity: widget.hideSwitcher ? 0 : 1,
+              child: SwitcherButton(
+                labels: [infoList[0].label, infoList[1].label],
+                onSwitch: widget.hideSwitcher ? (_) {} : _switch,
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
## Description

Change the way we hide the currency switcher. Make it invisible and unclickable instead of removing it. 

## Issue
N/A

## Testing scenarios

- [ ] Scenarios 1: Make sure when currency switcher is hidden, it is unclickable and invisible.
- [ ] Scenarios 2: Make sure currency switcher works well when visible

## Impact

Make currency switcher hideable

## Rollback

Revert commit

___

Owner: Tomi
