### PR TITLE
Al add color to filledbutton

### DIFF
--- a/lib/stories/buttons.dart
+++ b/lib/stories/buttons.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter_ui_kit/color.dart';
 import 'package:flutter_ui_kit/story_book/expandable_story.dart';
 import 'package:flutter_ui_kit/story_book/prop_updater/bool_prop_updater.dart';
@@ -39,6 +41,7 @@ class Buttons extends StatelessWidget {
           'fullWidth': false,
           'narrow': false,
           'taskDuration': 300,
+          'overrideColor': false,
         },
         formBuilder: (context, props, updateProp) {
           return ListView(
@@ -71,6 +74,11 @@ class Buttons extends StatelessWidget {
                 updateProp: updateProp,
                 propKey: 'narrow',
               ),
+              BoolPropUpdater(
+                props: props,
+                updateProp: updateProp,
+                propKey: 'overrideColor',
+              ),
             ],
           );
         },
@@ -87,11 +95,15 @@ class Buttons extends StatelessWidget {
             };
           }
 
+          const colors = [Colors.red, Colors.blue, Colors.purple, Colors.teal, Colors.brown];
+          final randIndex = Random().nextInt(5);
+
           return FilledButton(
             props['text'],
             onPressed: onPressed,
             fullWidth: props['fullWidth'],
             narrow: props['narrow'],
+            color: props['overrideColor'] ? colors[randIndex] : null,
           );
         },
       ),

--- a/lib/widgets/filled_button.dart
+++ b/lib/widgets/filled_button.dart
@@ -57,6 +57,7 @@ class _FilledButtonState extends State<FilledButton> with ButtonMixin {
         textColor: AppColor.deepWhite,
         disabledTextColor: AppColor.deepWhite,
         disabledColor: AppColor.mediumGrey,
+        color: color,
         highlightColor: color ?? AppColor.darkerGreen,
       ),
     );

--- a/lib/widgets/filled_button.dart
+++ b/lib/widgets/filled_button.dart
@@ -10,6 +10,7 @@ class FilledButton extends StatefulWidget {
   final bool narrow;
   final EdgeInsetsGeometry padding;
   final TextStyle textStyle;
+  final Color color;
 
   FilledButton(
     this.text, {
@@ -18,6 +19,7 @@ class FilledButton extends StatefulWidget {
     this.narrow = false,
     this.padding,
     this.textStyle,
+    this.color,
     Key key,
   })  : assert(text != null),
         super(key: key);
@@ -28,6 +30,8 @@ class FilledButton extends StatefulWidget {
 
 class _FilledButtonState extends State<FilledButton> with ButtonMixin {
   bool _enabled = true;
+
+  Color get color => widget.color;
 
   @override
   Widget build(BuildContext context) {
@@ -53,7 +57,7 @@ class _FilledButtonState extends State<FilledButton> with ButtonMixin {
         textColor: AppColor.deepWhite,
         disabledTextColor: AppColor.deepWhite,
         disabledColor: AppColor.mediumGrey,
-        highlightColor: AppColor.darkerGreen,
+        highlightColor: color ?? AppColor.darkerGreen,
       ),
     );
   }


### PR DESCRIPTION
## Description

Add ability to override filled button default colot

## Issue
(#DOPE-123)

## Testing scenarios

- [ ] Scenarios 1: Make sure filled button still works as expected
- [ ] Scenarios 2: Make sure filled button color can be overriden

## Impact

Allow filled button color to be overriden

## Rollback

Revert commit

___

QA Tester: 

Approved: 
