### PR TITLE
EN-1315. add onTap callback to CopyToClipboard component

### DIFF
--- a/lib/ui/text/copy_to_clipboard.dart
+++ b/lib/ui/text/copy_to_clipboard.dart
@@ -5,8 +5,9 @@ import '../colors.dart';
 
 class CopyToClipboard extends StatelessWidget {
   final String value;
+  final Function onTapCallback;
 
-  const CopyToClipboard({this.value});
+  const CopyToClipboard({this.value, this.onTapCallback});
 
   @override
   Widget build(BuildContext context) {
@@ -20,6 +21,8 @@ class CopyToClipboard extends StatelessWidget {
               size: 20.0,
             )),
         onTap: () {
+          if (onTapCallback != null)
+            onTapCallback();
           Clipboard.setData(new ClipboardData(text: value));
           const snackBar =
               const SnackBar(content: const Text('Copied to clipboard'));

--- a/test/ui/text/copy_to_clipboard_test.dart
+++ b/test/ui/text/copy_to_clipboard_test.dart
@@ -3,8 +3,13 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_ui_kit/ui/text/copy_to_clipboard.dart';
+import 'package:mockito/mockito.dart';
 
 import '../test_method_channel.dart';
+
+class MockVoidFunction extends Mock implements Function {
+  void call();
+}
 
 void main() {
   group('Copy To Clipboard', () {
@@ -16,14 +21,16 @@ void main() {
     });
 
     testWidgets('copies on tap', (tester) async {
+      final onTapCallback = MockVoidFunction();
       setUpTestMethodChannel('flutter/platform', const JSONMethodCodec());
-      await tester.pumpWidget(const MaterialApp(
-        home: const Scaffold(body: const CopyToClipboard(value: '123456')),
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(body: CopyToClipboard(value: '123456', onTapCallback: onTapCallback.call)),
       ));
       await tester.tap(find.byType(Icon));
       expectMethodCall('Clipboard.setData', arguments: <String, dynamic>{
         'text': '123456',
       });
+      verify(onTapCallback.call());
     });
   });
 }


### PR DESCRIPTION
## Description

Related https://github.com/ChangeFinance/changeapp/pull/1583

add onTap callback to CopyToClipboard component

## Issue
EN-1315. add onTap callback to CopyToClipboard component.  https://change-finance.atlassian.net/browse/EN-1315

## Testing scenarios



## Impact

## Rollback

Revert commit

___

Owner:

QA Tester:

Approved:
