### PR TITLE
adding an option of color on the timeframe selector

### DIFF
--- a/lib/widgets/time_frame_selector.dart
+++ b/lib/widgets/time_frame_selector.dart
@@ -34,12 +34,14 @@ class TimeFrameSelector extends StatefulWidget {
   final Callback onChange;
   final TimeFrame defaultTimeFrame;
   final TimeFrame maxTimeFrame;
+  final Color enabledTimeFrameColor;
   final List<TimeFrame> exclude;
 
   const TimeFrameSelector({
     Key key,
     this.exclude = const [TimeFrame.THREE_MONTHS, TimeFrame.SIX_MONTHS, TimeFrame.THREE_YEARS],
     this.defaultTimeFrame = TimeFrame.ONE_DAY,
+    this.enabledTimeFrameColor,
     this.maxTimeFrame = TimeFrame.ONE_YEAR,
     this.onChange,
   }) : super(key: key);
@@ -73,6 +75,7 @@ class TimeFrameSelectorWidgetState extends State<TimeFrameSelector> {
     final checkedButton = FilledButton(TimeFrameHelper.getValue(selected),
         onPressed: onPressed,
         textStyle: AppText.graphTextStyle.copyWith(color: AppColor.deepWhite),
+        color: widget.enabledTimeFrameColor,
         padding: const EdgeInsets.all(0.0));
     final uncheckedButton = TextButton(
       TimeFrameHelper.getValue(selected),


### PR DESCRIPTION
## Description

This PR adds an optional color to the timeFrame selector buttons

## Issue
(#CFD-677)

## Testing scenarios

- [ ] Scenarios 1: Make sure that when you pass a color to the timeFrameSelector, the filledButton receives that color

## Impact

This impacts the timeFrame Selector and GRaphs with TimeFrames

## Rollback

Revert this PR

___
