### PR TITLE
Add ability to disable done button on swipe up to confirm layout

### DIFF
--- a/lib/stories/layouts.dart
+++ b/lib/stories/layouts.dart
@@ -414,6 +414,7 @@ class SwipeUpToConfirmLayoutWrapper extends StatefulWidget {
 
 class _SwipeUpToConfirmLayoutWrapperState extends State<SwipeUpToConfirmLayoutWrapper> {
   SwipeMode swipeMode = SwipeMode.swipe;
+  bool doneButtonEnabled = true;
 
   @override
   Widget build(BuildContext context) {
@@ -444,6 +445,7 @@ class _SwipeUpToConfirmLayoutWrapperState extends State<SwipeUpToConfirmLayoutWr
         Navigator.of(context).pop();
       },
       completionPrimaryButtonText: 'Done',
+      completionPrimaryButtonEnabled: doneButtonEnabled,
       completionSecondaryButtonAction: () {
         Navigator.of(context).pop();
       },
@@ -465,6 +467,12 @@ class _SwipeUpToConfirmLayoutWrapperState extends State<SwipeUpToConfirmLayoutWr
             } else {
               swipeMode = SwipeMode.swipe;
             }
+          });
+        }),
+        const SizedBox(height: 20),
+        FilledButton(doneButtonEnabled ? 'Disable Done button' : 'Enable Done button', onPressed: () {
+          setState(() {
+            doneButtonEnabled = !doneButtonEnabled;
           });
         })
       ],

--- a/lib/widgets/layout/swipe_confirmation.dart
+++ b/lib/widgets/layout/swipe_confirmation.dart
@@ -12,6 +12,7 @@ class SwipeConfirmation extends StatelessWidget {
   final Widget labelIcon;
   final String primaryButtonText;
   final Function primaryButtonAction;
+  final bool primaryButtonEnabled;
   final String secondaryButtonText;
   final Function secondaryButtonAction;
 
@@ -25,6 +26,7 @@ class SwipeConfirmation extends StatelessWidget {
     this.labelIcon,
     this.primaryButtonText = 'Done',
     this.primaryButtonAction,
+    this.primaryButtonEnabled = true,
     this.secondaryButtonText,
     this.secondaryButtonAction,
   }) : super(key: key);
@@ -84,20 +86,14 @@ class SwipeConfirmation extends StatelessWidget {
   Widget _buildButtons() {
     final buttons = <Widget>[];
     if (primaryButtonText != null && primaryButtonText != '') {
-      buttons.add(OutlinedButton(
-          primaryButtonText,
-          onPressed: primaryButtonAction,
-          fullWidth: true,
-          narrow: false,
-          alt: true
+      buttons.add(Opacity(
+        opacity: primaryButtonEnabled ? 1.0 : 0.5,
+        child: OutlinedButton(primaryButtonText,
+            onPressed: primaryButtonEnabled ? primaryButtonAction : null, fullWidth: true, narrow: false, alt: true),
       ));
     }
     if (secondaryButtonText != null && secondaryButtonText != '') {
-      buttons.add(TextButton(
-          secondaryButtonText,
-          onPressed: secondaryButtonAction,
-          alt: true
-      ));
+      buttons.add(TextButton(secondaryButtonText, onPressed: secondaryButtonAction, alt: true));
     }
 
     return Positioned(

--- a/lib/widgets/layout/swipe_up_to_confirm.dart
+++ b/lib/widgets/layout/swipe_up_to_confirm.dart
@@ -20,6 +20,7 @@ class SwipeUpToConfirmLayout extends StatefulWidget {
   final SwipeMode swipeMode;
   final String completionPrimaryButtonText;
   final Function completionPrimaryButtonAction;
+  final bool completionPrimaryButtonEnabled;
   final String completionSecondaryButtonText;
   final Function completionSecondaryButtonAction;
   final bool errorState;
@@ -37,6 +38,7 @@ class SwipeUpToConfirmLayout extends StatefulWidget {
     this.completeScreenLabelIcon,
     this.completionPrimaryButtonText = 'Primary button',
     this.completionPrimaryButtonAction,
+    this.completionPrimaryButtonEnabled = true,
     this.completionSecondaryButtonText = 'Secondary button',
     this.completionSecondaryButtonAction,
     this.errorState = false,
@@ -249,6 +251,7 @@ class _SwipeUpToConfirmLayoutState extends State<SwipeUpToConfirmLayout> with Ti
       labelText: widget.completeScreenLabelText,
       primaryButtonText: widget.completionPrimaryButtonText,
       primaryButtonAction: widget.completionPrimaryButtonAction,
+      primaryButtonEnabled: widget.completionPrimaryButtonEnabled,
       secondaryButtonText: widget.completionSecondaryButtonText,
       secondaryButtonAction: widget.completionSecondaryButtonAction,
       labelTranslation: _confirmViewLabelTranslation,


### PR DESCRIPTION
## Description

Add ability to disable done button on swipe up to confirm layout

## Issue
N/A

## Testing scenarios

- [ ] Scenarios 1: Done button on swipe up to confirm layout can be disabled

## Impact



## Rollback

Revert commit

___

Owner:
