### PR TITLE
EN- fix for calling setState() when widget is disposed

### DIFF
--- a/lib/widgets/filled_button.dart
+++ b/lib/widgets/filled_button.dart
@@ -65,7 +65,9 @@ class _FilledButtonState extends State<FilledButton> with ButtonMixin {
 
   void _setEnabled(bool enabled) {
     if (_enabled != enabled) {
-      setState(() => _enabled = enabled);
+      if (mounted) {
+        setState(() => _enabled = enabled);
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

(Add description of what was added in this PR)

## Issue
(#DOPE-123)

## Testing scenarios

- [ ] Scenarios 1: Make sure migration was applied
- [ ] Scenarios 2: Request /v1/me returns {"some":"object}
- [ ] Scenarios 3: When you create user you should not be able to use the same email 2 times

## Impact

(Add short description of what is effect and what can be effect with this feature/release)

## Rollback

(What and how to rollback the code.  Revert commit and run this sql to undo migration)

___

Owner: Alec

QA Tester: Kaisa

Approved: Bode
